### PR TITLE
Surface pre-release toggle and custom image button on Firmware page

### DIFF
--- a/src/assets/locales/en/translations.json
+++ b/src/assets/locales/en/translations.json
@@ -17,7 +17,8 @@
             "description": "This tool will make it easy to install or upgrade FluidNC on your controller. Plug in your controller and press Connect to continue.",
             "connect": "Connect",
             "connecting": "Connecting",
-            "establishing-connection": "Establishing connection to controller"
+            "establishing-connection": "Establishing connection to controller",
+            "decode-stack-trace": "Decode a stack trace without connecting"
         },
         "home": {
             "description": "You are now connected to a device, please choose an action below",

--- a/src/outlets/FluidNCOutlet.tsx
+++ b/src/outlets/FluidNCOutlet.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import { ControllerServiceContext } from "../context/ControllerServiceContext";
 import {
     CapturedBacktraceContext,
@@ -15,6 +15,10 @@ import Navigation from "../panels/navigation/Navigation";
 import Connection from "../pages/fluidnc/connection/Connection";
 import { TerminalPopup } from "../components/terminalpopup/TerminalPopup";
 import usePopupTerminalStore from "../store/PopupTerminalStore";
+import Page from "../model/Page";
+
+// Routes under /fluidnc that don't need an active controller connection.
+const CONNECTION_OPTIONAL_ROUTES: string[] = [Page.FLUIDNC_STACKTRACE_DECODER];
 
 const decoder = new TextDecoder();
 
@@ -25,6 +29,7 @@ const FluidNCOutletInner = () => {
     const [serialPort, setSerialPort] = useState<SerialPort | undefined>();
     const { setIsConnected } = usePopupTerminalStore();
     const backtraceContext = React.useContext(CapturedBacktraceContext);
+    const location = useLocation();
 
     const onCloseConnection = () => {
         setControllerService(undefined);
@@ -139,6 +144,17 @@ const FluidNCOutletInner = () => {
         !controllerService ||
         controllerStatus === ControllerStatus.DISCONNECTED
     ) {
+        if (CONNECTION_OPTIONAL_ROUTES.includes(location.pathname)) {
+            return (
+                <Container>
+                    <Row>
+                        <Col style={{ marginTop: "32px" }}>
+                            <Outlet />
+                        </Col>
+                    </Row>
+                </Container>
+            );
+        }
         return <Connection onConnect={setServices} />;
     }
 

--- a/src/pages/fluidnc/connection/Connection.tsx
+++ b/src/pages/fluidnc/connection/Connection.tsx
@@ -1,7 +1,9 @@
 import React, { useCallback } from "react";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { Spinner } from "../../../components";
 import ConnectionState from "../../../model/ConnectionState";
+import Page from "../../../model/Page";
 import { ControllerService } from "../../../services";
 import { SerialPort } from "../../../utils/serialport/SerialPort";
 import "./connection.scss";
@@ -135,6 +137,17 @@ const Connection = ({ onConnect }: Props) => {
                                             t("page.connection.connect")}
                                     </>
                                 </Button>
+                            </div>
+                        )}
+
+                        {connectionState === ConnectionState.DISCONNECTED && (
+                            <div
+                                className="mx-auto mt-3"
+                                style={{ textAlign: "center" }}
+                            >
+                                <Link to={Page.FLUIDNC_STACKTRACE_DECODER}>
+                                    {t("page.connection.decode-stack-trace")}
+                                </Link>
                             </div>
                         )}
 

--- a/src/pages/fluidnc/stacktracedecoder/StackTraceDecoder.tsx
+++ b/src/pages/fluidnc/stacktracedecoder/StackTraceDecoder.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Col, Row } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import PageTitle from "../../../components/pagetitle/PageTitle";
 import usePageView from "../../../hooks/usePageView";
 import useBacktraceLine from "../../../hooks/useBacktraceLine";
+import Page from "../../../model/Page";
 import "./StackTraceDecoder.scss";
 
 interface GithubRelease {
@@ -389,6 +391,7 @@ const StackTraceDecoder = () => {
 
     return (
         <>
+            <Link to={Page.FLUIDNC_HOME}>&larr; Back to FluidNC</Link>
             <PageTitle>Stack Trace Decoder</PageTitle>
             <p>Decode ESP32 stack backtraces using .addrinfo symbol files.</p>
 

--- a/src/panels/firmware/Firmware.tsx
+++ b/src/panels/firmware/Firmware.tsx
@@ -11,25 +11,14 @@ import "./Firmware.scss";
 import Choice from "../../components/choice";
 import PageTitle from "../../components/pagetitle/PageTitle";
 import FirmwareBreadCrumbList from "./FirmwareBreadcrumbList";
-import {
-    Col,
-    FormCheck,
-    Row,
-    Form,
-    DropdownButton,
-    Dropdown
-} from "react-bootstrap";
+import { Col, FormCheck, Row, Form, Button } from "react-bootstrap";
 import { useLocalStorage } from "../../hooks/useLocalStorage";
 import UploadCustomImageModal from "../../modals/installermodal/UploadCustomImageModal";
 import VersionCard from "../../components/cards/versioncard/VersionCard";
 import { SerialPortContext } from "../../context/SerialPortContext";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
-import {
-    faWarning,
-    faFileArrowUp,
-    faSliders
-} from "@fortawesome/free-solid-svg-icons";
+import { faWarning, faFileArrowUp } from "@fortawesome/free-solid-svg-icons";
 import { Alert } from "react-bootstrap";
 
 type Props = {
@@ -139,7 +128,7 @@ const Firmware = ({ onInstall, githubService }: Props) => {
     ]);
 
     useEffect(() => {
-        const getMcu = async (): string => {
+        const getMcu = async (): Promise<void> => {
             setIsDetecting(true);
             await serialPort
                 .getInfo()
@@ -203,88 +192,62 @@ const Firmware = ({ onInstall, githubService }: Props) => {
                     <p>{t("panel.firmware.install-description")}</p>
 
                     <Row>
-                        <Col sm="12" md="12" lg="9" xl="8">
-                            <Row>
-                                <Col>
-                                    <Form.Select
-                                        size="lg"
-                                        onChange={(event) =>
-                                            chooseFirmware(event.target.value)
-                                        }
-                                    >
-                                        {!releases?.length && (
-                                            <option>
-                                                {t("panel.firmware.loading")}
-                                            </option>
-                                        )}
-                                        {releases.map((release) => (
-                                            <option
-                                                key={release.id}
-                                                value={release.id}
-                                            >
-                                                {release.name}
-                                            </option>
-                                        ))}
-                                    </Form.Select>
-                                </Col>
-                                <Col
-                                    xs="3"
-                                    sm="3"
-                                    md="2"
-                                    lg="2"
-                                    style={{ paddingLeft: 0 }}
-                                >
-                                    <DropdownButton
-                                        variant="outline"
-                                        className={"d-grid"}
-                                        size="lg"
-                                        title={
-                                            <FontAwesomeIcon
-                                                icon={
-                                                    faSliders as IconDefinition
-                                                }
-                                            />
-                                        }
-                                    >
-                                        <Dropdown.Item
-                                            onClick={() =>
-                                                setShowPrerelease(
-                                                    (
-                                                        showPrerelease !==
-                                                        "true"
-                                                    ).toString()
-                                                )
-                                            }
-                                        >
-                                            {" "}
-                                            <FormCheck
-                                                type="switch"
-                                                label={t(
-                                                    "panel.firmware.show-prereleases"
-                                                )}
-                                                checked={
-                                                    showPrerelease === "true"
-                                                }
-                                            />
-                                        </Dropdown.Item>
-                                        <Dropdown.Divider />
-                                        <Dropdown.Item
-                                            onClick={() =>
-                                                setUploadCustomImage(true)
-                                            }
-                                        >
-                                            <FontAwesomeIcon
-                                                icon={
-                                                    faFileArrowUp as IconDefinition
-                                                }
-                                            />
-                                            {t(
-                                                "panel.firmware.install-custom-image"
-                                            )}
-                                        </Dropdown.Item>
-                                    </DropdownButton>
-                                </Col>
-                            </Row>
+                        <Col
+                            sm="12"
+                            md="12"
+                            lg="9"
+                            xl="8"
+                            className="d-flex align-items-center justify-content-between gap-3"
+                        >
+                            <FormCheck
+                                type="switch"
+                                label={t("panel.firmware.show-prereleases")}
+                                checked={showPrerelease === "true"}
+                                onChange={() =>
+                                    setShowPrerelease(
+                                        (showPrerelease !== "true").toString()
+                                    )
+                                }
+                            />
+                            <Button
+                                variant="outline-secondary"
+                                onClick={() => setUploadCustomImage(true)}
+                            >
+                                <FontAwesomeIcon
+                                    icon={faFileArrowUp as IconDefinition}
+                                />{" "}
+                                {t("panel.firmware.install-custom-image")}
+                            </Button>
+                        </Col>
+                    </Row>
+                    <Row>
+                        <Col
+                            sm="12"
+                            md="12"
+                            lg="9"
+                            xl="8"
+                            style={{ marginTop: "10px" }}
+                        >
+                            <Form.Select
+                                size="lg"
+                                value={
+                                    selectedRelease ? selectedRelease.id : ""
+                                }
+                                onChange={(event) =>
+                                    chooseFirmware(event.target.value)
+                                }
+                            >
+                                {!releases?.length && (
+                                    <option>
+                                        {t("panel.firmware.loading")}
+                                    </option>
+                                )}
+                                {releases.map((release) => (
+                                    <option key={release.id} value={release.id}>
+                                        {release.name}
+                                    </option>
+                                ))}
+                            </Form.Select>
                         </Col>
                     </Row>
                 </>


### PR DESCRIPTION
## Summary
- The "Show pre-releases" switch and "Install a custom image" button were hidden behind a settings gear dropdown that many users never found. They now sit directly on the Firmware page, above the release selector.
- The release `<Form.Select>` was uncontrolled, so toggling "Show pre-releases" silently changed the underlying release list without updating the visible selection — the last official release stayed shown even though a newer pre-release was now selected internally. Made the select controlled so the displayed selection always matches the actual latest release.
- Fixed an unrelated pre-existing TS error (`getMcu` was declared `async (): string` instead of `async (): Promise<void>`).

## Test plan
- [x] `npx tsc --noEmit` passes for `Firmware.tsx`
- [x] Manually verified in `npm start` dev build that the switch and button render above the selector and toggling pre-releases updates the visible selection